### PR TITLE
Fix Patchouli containing LF characters.

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CheckStyle-IDEA" serialisationVersion="2">
+    <checkstyleVersion>10.12.0</checkstyleVersion>
+    <scanScope>JavaOnly</scanScope>
+    <copyLibs>true</copyLibs>
+    <option name="thirdPartyClasspath" />
+    <option name="activeLocationIds" />
+    <option name="locations">
+      <list>
+        <ConfigurationLocation id="bundled-sun-checks" type="BUNDLED" scope="All" description="Sun Checks">(bundled)</ConfigurationLocation>
+        <ConfigurationLocation id="bundled-google-checks" type="BUNDLED" scope="All" description="Google Checks">(bundled)</ConfigurationLocation>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="18" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" default="true" project-jdk-name="temurin-18" project-jdk-type="JavaSDK">
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/PKPCPBP.test.iml" filepath="$PROJECT_DIR$/.idea/modules/PKPCPBP.test.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/modules/PKPCPBP.test.iml
+++ b/.idea/modules/PKPCPBP.test.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../src/test" dumb="true">
+      <sourceFolder url="file://$MODULE_DIR$/../../src/test/java" isTestSource="true" />
+    </content>
+  </component>
+</module>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,15 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="9b3116e4-3fa0-43dc-bc65-57570039e5dc" name="Changes" comment="">
+    <list default="true" id="9b3116e4-3fa0-43dc-bc65-57570039e5dc" name="Changes" comment="do the \n removal earlier, replace with &quot;&quot; so there are no LF chars in patchouli, add testing library for stupid simple test.">
+      <change afterPath="$PROJECT_DIR$/.idea/checkstyle-idea.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/modules.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/modules/PKPCPBP.test.iml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/at/at/petrak/pkpcpbp/filters/FlatteningJson5TransmogrifierTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/compiler.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/compiler.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/functionalTest/java/pkpcpbp/PKPCPBPPluginFunctionalTest.java" beforeDir="false" />
+      <change beforePath="$PROJECT_DIR$/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/build.gradle.kts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/at/petrak/pkpcpbp/filters/JsonUtil.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/at/petrak/pkpcpbp/filters/JsonUtil.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -46,6 +52,29 @@
                 <item name="Tasks" type="e4a08cd1:TasksNode" />
                 <item name="build" type="c8890929:TasksNode$1" />
               </path>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="PKPCPBP" type="f1a62948:ProjectNode" />
+                <item name="Tasks" type="e4a08cd1:TasksNode" />
+                <item name="other" type="c8890929:TasksNode$1" />
+              </path>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="PKPCPBP" type="f1a62948:ProjectNode" />
+                <item name="Dependencies" type="6de06a37:ExternalSystemViewDefaultContributor$MyDependenciesNode" />
+              </path>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="PKPCPBP" type="f1a62948:ProjectNode" />
+                <item name="Dependencies" type="6de06a37:ExternalSystemViewDefaultContributor$MyDependenciesNode" />
+                <item name="compileClasspath" type="62daadca:ExternalSystemViewDefaultContributor$DependencyScopeExternalSystemNode" />
+              </path>
+              <path>
+                <item name="" type="6a2764b6:ExternalProjectsStructure$RootNode" />
+                <item name="PKPCPBP" type="f1a62948:ProjectNode" />
+                <item name="Dependencies" type="6de06a37:ExternalSystemViewDefaultContributor$MyDependenciesNode" />
+                <item name="testCompileClasspath" type="62daadca:ExternalSystemViewDefaultContributor$DependencyScopeExternalSystemNode" />
+              </path>
             </expand>
             <select />
           </tree_state>
@@ -57,11 +86,15 @@
     <option name="RECENT_TEMPLATES">
       <list>
         <option value="Class" />
+        <option value="JUnit5 Test Class" />
       </list>
     </option>
   </component>
   <component name="FormatOnSaveOptions">
     <option name="myRunOnSave" value="true" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
   <component name="MarkdownSettingsMigration">
     <option name="stateVersion" value="1" />
@@ -70,22 +103,49 @@
     <option name="myRunOnSave" value="true" />
   </component>
   <component name="ProjectId" id="2NSwCIKmdh6t0PwC4uBTo8uIRbv" />
+  <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
   <component name="ProjectViewState">
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;actions.on.save&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
+    "create.test.in.the.same.root": "true",
+    "git-widget-placeholder": "main",
+    "jdk.selected.JAVA_MODULE": "jbr-17",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "settings.editor.selected.configurable": "actions.on.save",
+    "vue.rearranger.settings.migration": "true"
+  },
+  "keyToStringList": {
+    "DatabaseDriversLRU": [
+      "hive"
+    ]
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
+      <recent name="D:\Programming\MinecraftMods\PKPCPBP\src\test\java\at" />
       <recent name="$PROJECT_DIR$" />
       <recent name="$PROJECT_DIR$/plugin/src/main/java/at/petrak" />
+    </key>
+    <key name="CreateTestDialog.Recents.Supers">
+      <recent name="" />
+    </key>
+    <key name="MoveClassesOrPackagesDialog.RECENTS_KEY">
+      <recent name="at.petrak.pkpcpbp.filters" />
+    </key>
+    <key name="CreateTestDialog.RecentsKey">
+      <recent name="at.petrak.pkpcpbp.filters" />
     </key>
     <key name="CopyClassDialog.RECENTS_KEY">
       <recent name="at.petrak.pkpcpbp.cfg" />
@@ -93,8 +153,56 @@
       <recent name="at.petrak.pkpcpbp.filters" />
     </key>
   </component>
-  <component name="RunManager">
-    <configuration name="PKPCPBP [build]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+  <component name="RunManager" selected="Gradle.FlatteningJson5TransmogrifierTest.test">
+    <configuration name="FlatteningJson5TransmogrifierTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;at.at.petrak.pkpcpbp.filters.FlatteningJson5TransmogrifierTest&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <ForceTestExec>true</ForceTestExec>
+      <method v="2" />
+    </configuration>
+    <configuration name="FlatteningJson5TransmogrifierTest.test" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;at.at.petrak.pkpcpbp.filters.FlatteningJson5TransmogrifierTest.test&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <ForceTestExec>true</ForceTestExec>
+      <method v="2" />
+    </configuration>
+    <configuration name="PKPCPBP [check]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -105,7 +213,7 @@
         </option>
         <option name="taskNames">
           <list>
-            <option value="build" />
+            <option value="check" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -113,11 +221,60 @@
       <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
       <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
       <DebugAllEnabled>false</DebugAllEnabled>
+      <ForceTestExec>false</ForceTestExec>
+      <method v="2" />
+    </configuration>
+    <configuration name="PKPCPBP [testClasses]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value="testClasses" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <ForceTestExec>false</ForceTestExec>
+      <method v="2" />
+    </configuration>
+    <configuration name="PKPCPBP [test]" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value="test" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <ForceTestExec>false</ForceTestExec>
       <method v="2" />
     </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="Gradle.PKPCPBP [build]" />
+        <item itemvalue="Gradle.FlatteningJson5TransmogrifierTest.test" />
+        <item itemvalue="Gradle.PKPCPBP [check]" />
+        <item itemvalue="Gradle.PKPCPBP [test]" />
+        <item itemvalue="Gradle.PKPCPBP [testClasses]" />
+        <item itemvalue="Gradle.FlatteningJson5TransmogrifierTest" />
       </list>
     </recent_temporary>
   </component>
@@ -129,7 +286,15 @@
       <option name="number" value="Default" />
       <option name="presentableId" value="Default" />
       <updated>1679670662948</updated>
+      <workItem from="1686578009042" duration="4062000" />
     </task>
     <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="do the \n removal earlier, replace with &quot;&quot; so there are no LF chars in patchouli, add testing library for stupid simple test." />
+    <option name="LAST_COMMIT_MESSAGE" value="do the \n removal earlier, replace with &quot;&quot; so there are no LF chars in patchouli, add testing library for stupid simple test." />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 
     implementation(group = "net.darkhax.curseforgegradle", name = "CurseForgeGradle", version = "1.0.10")
     implementation(group = "com.modrinth.minotaur", name = "Minotaur", version = "2.+")
+    implementation("org.junit.jupiter:junit-jupiter:5.8.1")
 }
 
 gradlePlugin {
@@ -59,5 +60,15 @@ publishing {
 
     repositories {
         maven("file:///" + System.getenv("local_maven"))
+    }
+}
+
+tasks.named<Test>("test") {
+    useJUnitPlatform()
+
+    maxHeapSize = "1G"
+
+    testLogging {
+        events("passed")
     }
 }

--- a/src/main/java/at/petrak/pkpcpbp/filters/JsonUtil.java
+++ b/src/main/java/at/petrak/pkpcpbp/filters/JsonUtil.java
@@ -3,7 +3,6 @@ package at.petrak.pkpcpbp.filters;
 import blue.endless.jankson.Jankson;
 import blue.endless.jankson.JsonGrammar;
 import blue.endless.jankson.JsonObject;
-import blue.endless.jankson.JsonPrimitive;
 import blue.endless.jankson.api.SyntaxError;
 
 import java.io.IOException;
@@ -15,11 +14,11 @@ public class JsonUtil {
 
     public static StringReader processJson(Reader in, boolean flatten) throws IOException, SyntaxError {
         var jsonSrc = JsonUtil.jesusChristJustGetTheGodDamnReaderIntoAFuckingStream(in);
-        JsonObject asJson = JANKSON.load(jsonSrc.replace("\r\n", "\n"));
+        JsonObject asJson = JANKSON.load(jsonSrc.replace("\r\n", "\n").replaceAll("\\n\\s*", ""));
 
         JsonObject out = flatten
-            ? flattenObject(asJson)
-            : asJson;
+                ? flattenObject(asJson)
+                : asJson;
         var unTfedSrc = out.toJson(JsonGrammar.STRICT);
         return new StringReader(unTfedSrc);
     }
@@ -52,16 +51,6 @@ public class JsonUtil {
 
             if (val instanceof JsonObject subobj) {
                 flattenInner(key, subobj, out);
-            } else if (val instanceof JsonPrimitive prim
-                && prim.getValue() instanceof String text
-                && text.startsWith(">>>")) {
-                // In case i want to actually use the pipe char in the lang somewhere, require a start sigil
-                // also, I'm not sure *what* cypher's doing but I am NOT getting newlines in my input at all.
-                // so, we insert them ourselves
-                String validArea = text.substring(text.indexOf('|'));
-                String processed = validArea.replaceAll("\\|\\s*", "\n");
-                // This puts a newline out the front so remove that
-                out.put(key, new JsonPrimitive(processed.substring(1)));
             } else {
                 out.put(key, val);
             }

--- a/src/test/java/at/at/petrak/pkpcpbp/filters/FlatteningJson5TransmogrifierTest.java
+++ b/src/test/java/at/at/petrak/pkpcpbp/filters/FlatteningJson5TransmogrifierTest.java
@@ -1,0 +1,52 @@
+package at.at.petrak.pkpcpbp.filters;
+
+import at.petrak.pkpcpbp.filters.FlatteningJson5Transmogrifier;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+class FlatteningJson5TransmogrifierTest {
+    private static final String testInput = """
+            {
+              lore: {
+                "": "Lore",
+                desc: "I have uncovered some letters and text not of direct relevance to my art. \\
+                  But, I think I may be able to divine some of the history of the world from these. Let me see..."
+              },
+                    
+              interop: {
+                "": "Cross-Mod Compatibility",
+                desc: "It appears I have installed some mods Hexcasting interoperates with! I've detailed them here."
+              },
+             \s
+              patterns: {
+                "": "Patterns",
+                desc: "A list of all the patterns I've discovered, as well as what they do."
+              },
+              spells: {
+                "": "Spells",
+                desc: "Patterns and actions that perform a magical effect on the world."
+              },
+              great_spells: {
+                "": "Great Spells",
+                desc: "The spells catalogued here are purported to be of legendary difficulty and power. \\
+                  They seem to have been recorded only sparsely (for good reason, the texts claim). \\
+                  It's probably just the ramblings of extinct traditionalists, though -- a pattern's a pattern.$(br2)\\
+                  What could possibly go wrong?"
+              },
+            }""";
+
+    @Test
+    void test() {
+        var reader = new StringReader(testInput);
+
+        try {
+            var it = new FlatteningJson5Transmogrifier(reader);
+            System.out.println(it);
+        } catch (Exception e) {
+            fail("building transmogrifier failed for this reason: ", e);
+        }
+    }
+}


### PR DESCRIPTION
do the \n removal earlier, replace with "" so there are no LF chars in patchouli, add testing library for stupid simple test. This assumes that the intermediary .json isn't meant to be developer-facing, i.e. that it's fine for it to have messed up white spacing as long as the patchouli book looks correct.